### PR TITLE
Fix Expired Meetings

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -123,6 +123,10 @@ public class ParserUtil {
             DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd-MM-uuuu HH:mm")
                     .withResolverStyle(ResolverStyle.STRICT);
             LocalDateTime meetingTimeFormatted = LocalDateTime.parse(trimmedMeetingTime, dtf);
+            MeetingTime mt = new MeetingTime(meetingTimeFormatted);
+            if (mt.isExpiredMeetingTime()) {
+                throw new ParseException(MeetingTime.MESSAGE_FUTURE_CONSTRAINT);
+            }
             return new MeetingTime(meetingTimeFormatted);
         } catch (DateTimeParseException dateTimeParseException) {
             throw new ParseException(MeetingTime.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -119,8 +120,9 @@ public class ParserUtil {
         requireNonNull(meetingTime);
         String trimmedMeetingTime = meetingTime.trim();
         try {
-            LocalDateTime meetingTimeFormatted = LocalDateTime.parse(trimmedMeetingTime,
-                    DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
+            DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd-MM-uuuu HH:mm")
+                    .withResolverStyle(ResolverStyle.STRICT);
+            LocalDateTime meetingTimeFormatted = LocalDateTime.parse(trimmedMeetingTime, dtf);
             return new MeetingTime(meetingTimeFormatted);
         } catch (DateTimeParseException dateTimeParseException) {
             throw new ParseException(MeetingTime.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/MeetingBook.java
+++ b/src/main/java/seedu/address/model/MeetingBook.java
@@ -103,7 +103,7 @@ public class MeetingBook implements ReadOnlyMeetingBook {
 
     @Override
     public ObservableList<Meeting> getMeetingList() {
-        return meetings.asUnmodifiableObservableList().filtered(m -> !m.getTime().isExpiredMeetingTime());
+        return meetings.asUnmodifiableObservableList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/MeetingBook.java
+++ b/src/main/java/seedu/address/model/MeetingBook.java
@@ -103,7 +103,7 @@ public class MeetingBook implements ReadOnlyMeetingBook {
 
     @Override
     public ObservableList<Meeting> getMeetingList() {
-        return meetings.asUnmodifiableObservableList();
+        return meetings.asUnmodifiableObservableList().filtered(m -> !m.getTime().isExpiredMeetingTime());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/meeting/MeetingTime.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingTime.java
@@ -16,6 +16,9 @@ public class MeetingTime {
     public static final String MESSAGE_CONSTRAINTS =
             "Meeting time must be in the following format: dd-MM-yyyy HH:mm\n Example: 25-05-2022 23:59";
 
+    public static final String MESSAGE_FUTURE_CONSTRAINT =
+            "Meeting time must be in the future, not in past";
+
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-uuuu HH:mm")
             .withResolverStyle(ResolverStyle.STRICT);
     public final LocalDateTime dateTime;

--- a/src/main/java/seedu/address/model/meeting/MeetingTime.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingTime.java
@@ -6,6 +6,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.Date;
 
 /**
@@ -15,7 +16,8 @@ public class MeetingTime {
     public static final String MESSAGE_CONSTRAINTS =
             "Meeting time must be in the following format: dd-MM-yyyy HH:mm\n Example: 25-05-2022 23:59";
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-uuuu HH:mm")
+            .withResolverStyle(ResolverStyle.STRICT);
     public final LocalDateTime dateTime;
 
     /**
@@ -75,7 +77,7 @@ public class MeetingTime {
      * @return formatted date
      */
     public static String prettyDate(LocalDateTime dateTime) {
-        String date = dateTime.format(DateTimeFormatter.ofPattern("MMM dd yyyy"));
+        String date = dateTime.format(DateTimeFormatter.ofPattern("MMM dd uuuu"));
         return date;
     }
 

--- a/src/test/java/seedu/address/model/meeting/MeetingTimeTest.java
+++ b/src/test/java/seedu/address/model/meeting/MeetingTimeTest.java
@@ -28,6 +28,8 @@ public class MeetingTimeTest {
         assertFalse(MeetingTime.isValidMeetingTime(invalidDate));
         String invalidTime = "01-01-2022 34:56"; // Time is invalid
         assertFalse(MeetingTime.isValidMeetingTime(invalidTime));
+        invalidDate = "31-02-2022 12:30";
+        assertFalse(MeetingTime.isValidMeetingTime(invalidDate));
 
         // valid time
         String validTime = "01-01-2022 12:30";


### PR DESCRIPTION
1. Add Strict ResolverStyle so LocalDateTime does not auto-fix incorrect dates like 30-02-2022. Change formatter from yyyy to uuuu.
2. Revert deletion of meetings if they are expired.
Closes #179 Closes #170 