### PR TITLE
Updated Manual testing for Add, Edit, Back

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -875,6 +875,9 @@ testers are expected to do more *exploratory* testing.
    1. Test case for some fields: `add n/Peter ph/63339888 l/Home e/peter@gmail.com l/Personal`
       Expected: Transferred to the Contact Details Page and "New person added" success message is displayed.
       
+   1. Test case for no fields: `add`
+      Expected: Invalid command format error message.
+      
    1. Test case for one invalid prefix: `add name/Wayne`
       Expected: Invalid command format error message.
       
@@ -907,6 +910,9 @@ testers are expected to do more *exploratory* testing.
    
    1. Test case with multiple valid field inputs: `edit ph/63339888 e/guy@people.com a/Average apartment t/not funny actually`
       Expected: Contact information updated message is displayed.
+      
+   1. Test case for no fields: `edit`
+      Expected: Field error message is displayed.
    
    1. Test case with one invalid field input amongst valid inputs: `edit ph/90909999 e/ihateemails a/Pineapple`
       Expected: Invalid email format error message is displated.
@@ -920,7 +926,7 @@ testers are expected to do more *exploratory* testing.
    1. Test case with valid name input: `edit n/Johnny`, `edit n/Johnny Number 1`
       Expected: Contact information updated message is displayed.
       
-   1. Test case with invalid name input: `edit n/R@dical`, edit n/`
+   1. Test case with invalid name input: `edit n/R@dical`, `edit n/`
       Expected: Invalid name format message is displayed.
       
    1. Test case with valid jobtitle input: `edit j/Job`, `edit j/Job Number 1`

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -857,7 +857,7 @@ testers are expected to do more *exploratory* testing.
 
 1. Initial launch
 
-   1. Download the jar file and copy into an empty folder
+   1. Download the jar file and copy into an empty folder.
 
    1. Double-click the jar file Expected: Shows the GUI with a set of sample contacts. The window size may not be optimum.
 
@@ -870,7 +870,87 @@ testers are expected to do more *exploratory* testing.
       
 ### 8.2 Adding a person
 
+1. Adding a person
+
+   1. Prerequisites: Have an empty contacts list. (_Note: The clear and back command may come in handy_)
+   
+   1. Test case for basic case: `add n/John Doe'<br>
+      Expected: Transferred to the Contact Details Page and "New person added" success message is displayed.
+      
+   1. Test case for all fields: `add n/Michael ph/62334555 l/Home e/michael@gmail.com l/Personal a/Big Mansion l/Home j/Jobs c/Company t/Happy t/Man`
+      Expected: Transferred to the Contact Details Page and "New person added" success message is displayed.
+      
+   1. Test case for some fields: `add n/Peter ph/63339888 l/Home e/peter@gmail.com l/Personal`
+      Expected: Transferred to the Contact Details Page and "New person added" success message is displayed.
+      
+   1. Test case for one invalid prefix: `add name/Wayne`
+      Expected: Invalid command format error message.
+      
+   1. Test case for one invalid name input: `add n/1` 
+      Expected: Invalid name format error message.
+      
+   1. Test case for input without name: `add ph/999 a/Big Hotel`
+      Expected: Invalid command format error message.
+      
+   1. Test case for input with one invalid field input: `add n/Harry ph/Numbers`
+      Expected: Invalid phone format error message.
+      
+   1. Test case for inputs with multiple invalid field inputs: `add n/Harry ph/Numbers j/###`
+      Expected: Invalid phone format error message.
+      
+   1. Test case for duplicate contacts: `add n/David` then `back` and `add n/David`
+      Expected: Duplicate person error message.
+      
+   1. Test case for contacts with same name but different tags: `add n/Storm t/sunny` then `back` and `add n/Storm t/windy`
+      Expected: Both contacts successfully added.
+
 ### 8.3 Editing a person
+
+1. Editing a person
+
+   1. Prerequisites: Preferably an empty contacts list. Do `add n/Zachary Davidson` and stay at the Contact Details Page before starting the testing. The list of test cases have to be followed in order for the testing to work.
+   
+   1. Test case with one valid field input: `edit t/funny`
+      Expected: Contact information updated message is displayed.
+   
+   1. Test case with multiple valid field inputs: `edit ph/63339888 e/guy@people.com a/Average apartment t/not funny actually`
+      Expected: Contact information updated message is displayed.
+   
+   1. Test case with one invalid field input amongst valid inputs: `edit ph/90909999 e/ihateemails a/Pineapple`
+      Expected: Invalid email format error message is displated.
+      
+   1. Test case with one invalid field input and one valid field input: `edit ph/98889777 ph/no`
+      Expected: Invalid phone format error message is displayed.
+      
+   1. Test case with unnecessary additions to front of inputs: `edit 1 t/me`, `edit Zachary Davidson t/me`
+      Expected: Invalid command format message is displayed.
+      
+   1. Test case with valid name input: `edit n/Johnny`, `edit n/Johnny Number 1`
+      Expected: Contact information updated message is displayed.
+      
+   1. Test case with invalid name input: `edit n/R@dical`, edit n/`
+      Expected: Invalid name format message is displayed.
+      
+   1. Test case with valid jobtitle input: `edit j/Job`, `edit j/Job Number 1`
+      
+   1. Test case with invalid jobtitle input: `edit j/Ch@f`, `edit j/Boss (CEO)`, `edit j/`
+      Expected: Invalid jobtitle format message is displayed.
+      
+   1. Test case with valid company input: `edit c/Good company`, `edit c/Company Number 1`
+      Expected: Contact information updated message is displayed.
+      
+   1. Test case with invalid company input: `edit c/`
+      Expected: Invalid company format message is displayed.
+   
+   1. Test case with valid label input: `edit ph/999 l/Police`, `edit e/email@gmail.com l/Email`, `edit a/address l/home`, `edit ph/999 l/9aS@1`
+      Expected: Contact information updated message is displayed.
+   
+   1. Test case with invalid label input: `edit l/onlyLabel`
+      Expected: Invalid command format message is displayed.
+      
+   1. Test case with invalid label input: `edit ph/67676767 l/`
+      Expected: Invalid label format message is displayed.
+      
 
 ### 8.4 Deleting a field
 
@@ -898,6 +978,16 @@ testers are expected to do more *exploratory* testing.
 ### 8.9 View
 
 ### 8.10 Back
+
+1. Going back to the Home Page from the Contact Details Page
+
+   1. Prerequisites: Have at least 1 contact and start at the home page.
+
+   1. Test case for view command: `view 1` then `back`
+      Expected: Home Page -> Contact Details Page -> Home Page.
+      
+   1. Test case for add command: `add n/Vivaldi` then `back`
+      Expected: Home Page -> Contact Details Page -> Home Page.
 
 ### 8.11 Adding a meeting
 

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -16,7 +16,6 @@ public class Address {
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
-    //private static final String NO_SPACE = "^[^\\s].*$";
 
     public final String address;
 


### PR DESCRIPTION
I intentionally left out the success cases for pronouns, tags and addresses inside the test cases for Edit because there are no invalid inputs messages appearing for them. So if I were to just include the valid test cases, it would make it obvious that the invalid test cases are not working. Am I overthinking this and should I just include the valid test cases?